### PR TITLE
Made the javascript code more idiomatic and tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 html {
-    font-family: Comic Sans MS;
+    font-family: Comic Sans MS, sans-serif;
     box-sizing: border-box;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 html {
-    font-family: Comic Sans MS, sans-serif;
+    font-family: Comic Sans MS;
     box-sizing: border-box;
 }
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Magic 8Ball</title>
 
+    <script src="js/main.js" defer></script>
+
     <link rel="stylesheet" href="css/style.css">
 
 </head>
@@ -14,7 +16,7 @@
         <h1>The Magic 8Ball</h1>
         <p>Let the Magic 8Ball predict your future</p>
 
-    
+
         <label for="uname">UserName (Optional)</label><br>
         <input type="text" id="uname" name="uname" placeholder="UserName here"><br>
         <label for="question">Ask your question</label><br>
@@ -22,9 +24,5 @@
         <button id="ask-question">Ask</button>
         <p id="result"></p>
     </div>
-    
-
-    <script src="js/main.js"></script>
-
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,44 +1,46 @@
-const button = document.querySelector('#ask-question');
-let userName = 'Joe Biden';
-let userQuestion = 'Will I die';
+const button = document.getElementById('ask-question');
+const userNameInput = document.getElementById('uname');
+const userQuestionInput = document.getElementById('question');
+const result = document.getElementById('result');
 
-window.onload = function() {
-  button.addEventListener('click', handleButtonClick);
-};
+const eightBallAnswers = [
+  'It is certain',
+  'It is decidedly so',
+  'Reply hazy try again',
+  'Cannot predict now',
+  'Do not count on it',
+  'My sources say no',
+  'Outlook not so good',
+  'Signs point to yes'
+];
 
-function handleButtonClick(event)
-{
-  userName = document.querySelector('#uname').value;
-  userQuestion = document.querySelector('#question').value;
+button.addEventListener('click', handleButtonClick);
 
+function handleButtonClick(event) {
+  let userName = userNameInput.value;
+  let userQuestion = userQuestionInput.value;
 
-  let eightBall = '';
-  let p_tag = document.querySelector('#result');
-
-const eightBallAnswers = new Array(
-    'It is certain',
-    'It is decidedly so',
-    'Reply hazy try again',
-    'Cannot predict now',
-    'Do not count on it',
-    'My sources say no',
-    'Outlook not so good',
-    'Signs point to yes'
-);
-
-let randomNumber = Math.floor(Math.random() * eightBallAnswers.length);
-
-eightBall = eightBallAnswers[randomNumber]
-
-   if (userQuestion === '') {
-     p_tag.innerHTML = 'Please Fill in the Question'
-   } else if (userQuestion === 'will i become god') {
-     p_tag.innerHTML = userName === '' ? 'Hello!' : `Hello ${userName}!`;
-     p_tag.innerHTML += '<br />' + 'Question: ' + (userName === '' ? userQuestion : `${userName} asked ${userQuestion}`);
-     p_tag.innerHTML += '<br /><br />' + 'It is certain';
-   } else {
-    p_tag.innerHTML = userName === '' ? 'Hello!' : `Hello ${userName}!`;
-    p_tag.innerHTML += '<br />' + 'Question: ' + (userName === '' ? userQuestion : `${userName} asked ${userQuestion}`);
-    p_tag.innerHTML += '<br /><br />' + eightBall;
+  let randomNumber = Math.floor(Math.random() * eightBallAnswers.length);
+  let eightBall = eightBallAnswers[randomNumber];
+  if (/will +i +become +god/i.exec(userQuestion)) {
+    eightBall = 'It is certain';
   }
+
+  let res = '';
+
+  if (userQuestion === '') {
+    res = 'Please Fill in the Question'
+  } else {
+    if (userName === '') {
+      res = `Hello!`;
+      res += `<br />Question: ${userQuestion}`;
+    } else {
+      res = `Hello ${userName}!`;
+      res += `<br />Question: ${userName} asked ${userQuestion}`;
+    }
+
+    res += '<br /><br />' + eightBall;
+  }
+
+  result.innerHTML = res;
 }


### PR DESCRIPTION
I cleaned up the javascript code to make it a bit more idiomatic. Notable changes are:
- use `[]` notation instead of `new Array` notation
- put the javascript in a `defer` `<script>` block
- use `getElementById` instead of `querySelector`
- move the queries to the top of the file
- only write to `result.innerHTML` once
- accept variations of "will I become god" for the special case
- cleaned up the logic and de-duplicated code near the end of `handleButtonClick`
- ~~added `sans-serif` as a fallback font for users who don't have `Comic Sans` installed~~